### PR TITLE
Minor fix to histogram binning error

### DIFF
--- a/trippy/bgFinder.py
+++ b/trippy/bgFinder.py
@@ -119,7 +119,7 @@ class bgFinder:
         if display:
             figHist=pyl.figure('backgroundHistogram')
             ax=figHist.add_subplot(111)
-            pyl.hist(self.data,bins=min(100,len(self.data/10.)))
+            pyl.hist(self.data,bins=min(100,len(self.data)/10))
             (y0,y1)=ax.get_ylim()
             pyl.plot([g,g],[y0,y1],'r-',lw=2)
             pyl.title('Background %s'%(g))


### PR DESCRIPTION
I saw this minor error and figured I'd figure out how these pull requests work. 
It's clear from the original line that you meant to have the histogram use less than 100 bins if there is not enough data to justify it, however the parenthesis is set slightly wrong for this to work correctly. `len(a/10)` is always the same as `len(a)`, but different from `len(a)/10`. Oh, and the division by 10 must be an integer division, as `hist` barfs if you ask for a decimal number of bins.
