### PR TITLE
Expose ability to fit/fix various parameters in MCMCfitter

### DIFF
--- a/trippy/MCMCfit/MCMCfit.py
+++ b/trippy/MCMCfit/MCMCfit.py
@@ -209,7 +209,8 @@ class MCMCfitter:
                         bg = None, useErrorMap = False,
                         useLinePSF = False, fitRateAngle = False,
                         rate_in = None, angle_in = None, exptime = None, pixScale = None,
-                        verbose=False, rand_pos = 0.1):
+                        verbose=False, rand_pos = 0.1, 
+                        fitXY=True, fitM=True, fitXYM=True):
 
         """
         Using emcee (It's hammer time!) the provided image is fit using
@@ -228,6 +229,10 @@ class MCMCfitter:
                       is only honest if useErrorMap=True.
         useLinePSF - use the TSF? If not, use the PSF
         verbose - if set to true, lots of information printed to screen
+        fitXY - XY coordinate should be fitted in a seperate loop
+        fitM - m should be fitted in a seperate loop
+        fitXYM - XY coordinate and m should all be fit together
+                 (after previous loops or as only fitting)
         """
 
         print("Initializing sampler")
@@ -268,15 +273,20 @@ class MCMCfitter:
                 m_in = self.psf.repFact*self.psf.repFact*np.sum(dat)/np.sum(self.psf.fullPSF)
 
         if not fitRateAngle:
-
+          x, y, amp = x_in, y_in, m_in
+          dx, dy = np.array([rand_pos, rand_pos])
+          damp = amp * 0.25
+          if fitXY:
+            #fit first using input best guess amplitude
             nDim = 2
             r0 = []
             for ii in range(nWalkers):
-                r0.append(np.array([x_in,y_in])+sci.randn(2)*np.array([rand_pos,rand_pos]))
+                r0.append(np.array([x, y]) + sci.randn(2) * np.array([dx, dy]))
             r0 = np.array(r0)
-
-            #fit first using input best guess amplitude
-            sampler = emcee.EnsembleSampler(nWalkers,nDim,lnprob,args=[dat,(ai,bi,ci,di),self.psf,ue,useLinePSF,verbose,(-1,-1,m_in)])
+            sampler = emcee.EnsembleSampler(nWalkers, nDim, lnprob,
+                                            args=[dat, (ai, bi, ci, di),
+                                                  self.psf, ue, useLinePSF,
+                                                  verbose, (-1, -1, amp)])
             print("Executing xy burn-in... this may take a while.")
             pos, prob, state = sampler.run_mcmc(r0, nBurn)#, 10)
             sampler.reset()
@@ -290,15 +300,13 @@ class MCMCfitter:
             (x,y,junk) = out[0]
             dx = (out[1][0][1] - out[1][0][0])/2.0
             dy = (out[1][1][1] - out[1][1][0])/2.0
-
+          if fitM:
+            #now fit the amplitude using the best-fit x,y from above
             nDim = 1 # need to put two here rather than one because the fitresults code does a residual subtraction
             r0 = []
             for ii in range(nWalkers):
-                r0.append(np.array([m_in]) + sci.randn(1) * np.array([m_in*0.25]))
+                r0.append(np.array([amp]) + sci.randn(1) * np.array([damp]))
             r0 = np.array(r0)
-
-
-            #now fit the amplitude using the best-fit x,y from above
             #could probably cut the nBurn and nStep numbers down by a factor of 2
             sampler = emcee.EnsembleSampler(nWalkers, nDim, lnprob,
                                             args=[dat, (ai, bi, ci, di), self.psf, ue, useLinePSF, verbose, (x, y, -1)])
@@ -314,16 +322,13 @@ class MCMCfitter:
             out = self.fitResults()
             amp = out[0][0]
             damp = (out[1][0][1]-out[1][0][0])/2.0
-
-
+          if fitXYM:
             #now do a full 3D fit using a small number of burn and steps.
             nDim=3
             r0=[]
             for ii in range(nWalkers):
                 r0.append(np.array([x,y,amp])+sci.randn(3)*np.array([dx,dy,damp]))
             r0=np.array(r0)
-
-
             sampler=emcee.EnsembleSampler(nWalkers,nDim,lnprob,args=[dat,(ai,bi,ci,di),self.psf,ue,useLinePSF,verbose])
             print("Executing xy-amp burn-in... this may take a while.")
             pos, prob, state=sampler.run_mcmc(r0,nBurn)

--- a/tutorial/trippytutorial.ipynb
+++ b/tutorial/trippytutorial.ipynb
@@ -806,6 +806,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note1: Do not blindly use m_in=1000 for other data!",
+    "If the initial m_in guess is not close to the correct value, the MCMC fitter may not find a good fit. Unless you have a good estimate of m_in, use m_in=-1, which will force fitWithModelPSF to calculate a rough guess before fitting begins. Here we use m_in=1000 only because we have a good idea what the correct value is.\n",
+    "\n",
+    "Note 2: By default, fitWithModelPSF will first fit the XY pixel coordinate (holding m fixed), then fit m (holding XY fixed) and finally fit all three together. To change this behaviour, you can add the keyword fitXY=False, fitM=False or fitXYM=False.\n",
+    "\n",
     "Now get the fits results, including best fit and confidence region using the input value. 0.67 for 1-sigma is shown"
    ]
   },


### PR DESCRIPTION
We chatted about this when you visited. You were right that the ability to fit only certain parameters was sort of already there, although not as separate functions that the user can call directly. I have added a little bit, so that the user can turn on or off the fit of XY with M fixed, fit of M with XY fixed and the fit of XYM together.  