### PR TITLE
incorrect multiplication in the Moffat profile function

### DIFF
--- a/trippy/psf.py
+++ b/trippy/psf.py
@@ -491,7 +491,7 @@ class modelPSF:
 
         #normalized flux profile return 1.-(1.+(rad/self.alpha)**2)**(1.-self.beta)
         a2=self.alpha*self.alpha
-        return (self.beta-1)*(np.pi*a2)*(1.+(rad/self.alpha)**2)**(-self.beta)
+        return (self.beta-1)/(np.pi*a2)*(1.+(rad/self.alpha)**2)**(-self.beta)
 
     def FWHM(self, fromMoffatProfile=False, fromImData = False, method = 'median',frac = 0.5):
         """


### PR DESCRIPTION
One multiplication in the Moffat profile should be a division. This should have no effect on the results as it just changes the amplitude of the profile and not the shape.